### PR TITLE
Modify get_upf_version() to tolerate initial <?xml...?> tag

### DIFF
--- a/upf_to_json/upf_to_json.py
+++ b/upf_to_json/upf_to_json.py
@@ -6,10 +6,10 @@ from .upf1_to_json import parse_upf1_from_string
 from .upf2_to_json import parse_upf2_from_string
 
 def get_upf_version(upf):
-    line = upf.split('\n')[0]
-    if "<PP_INFO>" in line:
+    lines = upf.split('\n')
+    if "<PP_INFO>" in lines[0]:
         return 1
-    elif "UPF version" in line:
+    elif "UPF version" in lines[0] or "UPF version" in lines[1]:
         return 2
     return 0
 


### PR DESCRIPTION
Addresses #3. This seems to fix the issue for me, except that the code throws some warnings about size attributes not being defined for the pseudopotential in #3. This doesn't seem to affect the correctness of the code, but various tags (PP_R, PP_NLCC, PP_LOCAL, and PP_RHOATOM) don't have a size attribute in that pseudopotential, so the parsing can't double check that it got the right number of floats out of the text of each of these tags.